### PR TITLE
Change IOPS min values to 50 to match the API

### DIFF
--- a/lib/puppet/type/solidfire_volume.rb
+++ b/lib/puppet/type/solidfire_volume.rb
@@ -9,11 +9,11 @@ Puppet::Type.newtype(:solidfire_volume) do
   @doc = "Manage Volumes on solidfire cluster"
 
 #Ranges for the IOPS values
-MINIOPS_MIN = 100
+MINIOPS_MIN = 50
 MINIOPS_MAX = 15000
-MAXIOPS_MIN = 100
+MAXIOPS_MIN = 50
 MAXIOPS_MAX = 100000
-BURSTIOPS_MIN = 100
+BURSTIOPS_MIN = 50
 BURSTIOPS_MAX = 100000
 
   apply_to_all


### PR DESCRIPTION
The API specifies that the minimum value of each of these is 50 but the puppet type set it to 100.
