### PR TITLE
Add a property to solidfire_volume for enable512e

### DIFF
--- a/lib/puppet/provider/solidfire_volume/posix.rb
+++ b/lib/puppet/provider/solidfire_volume/posix.rb
@@ -57,6 +57,7 @@ Puppet::Type.type(:solidfire_volume).provide(:posix,
                  :burst_iops    => vol['qos']['burstIOPS'],
                  :volumeid      => vol['volumeID'],
                  :iqn           => vol['iqn'],
+                 :enable512e    => vol['enable512e'].to_s.to_sym,
                 }
   end
 
@@ -91,7 +92,7 @@ Puppet::Type.type(:solidfire_volume).provide(:posix,
         vol_id = transport(conn_info).CreateVolume({"name" => @resource[:name],
                                                     "accountID" => acct_id,
                                                     "totalSize" => size,
-                                                    "enable512e" => true,
+                                                    "enable512e" => @resource[:enable512e],
                                                     "qos" =>
                                     { "minIOPS" => @resource[:min_iops],
                                       "maxIOPS" => @resource[:max_iops],

--- a/lib/puppet/type/solidfire_volume.rb
+++ b/lib/puppet/type/solidfire_volume.rb
@@ -68,6 +68,11 @@ BURSTIOPS_MAX = 100000
     end
   end
 
+  newproperty(:enable512e) do
+    defaultto :true
+    newvalues(:true, :false)
+  end
+
   newproperty(:volumeid) do
     desc "VolumeID supplied by the cluster."
     validate do |value|


### PR DESCRIPTION
This adds a property to solidfire_volume that allows one to enable or disable the 512 byte emulation when creating a volume.  For better or for worse puppet uses symbols for booleans so the `.to_s.to_sym` is necessary when getting the current value from the API.
