### PR TITLE
Change the solidfire_vag properties to set an array of volume names

### DIFF
--- a/lib/puppet/provider/solidfire_vag/posix.rb
+++ b/lib/puppet/provider/solidfire_vag/posix.rb
@@ -47,10 +47,14 @@ Puppet::Type.type(:solidfire_vag).provide(:posix,
   end
 
   def self.get_vag_properties(vag)
+    volumes = vag['volumes'].collect do |vol_id|
+      volume = transport.getVolumeByID(vol_id)
+      volume['name']
+    end
     vag_hash = { :name          => vag['name'],
                  :ensure        => :present,
                  :vagid         => vag['volumeAccessGroupID"'],
-                 :volumes       => vag['volumes'],
+                 :volumes       => volumes,
                  :initiators    => vag['initiators'],
                 }
   end


### PR DESCRIPTION
Currently, the properties on a solidfire_vag are a list of volume IDs whereas the property that gets set in the config is a list of volume names.  This causes a diff every time the module runs.  This changes the property to get a list of names instead of IDs so there is only a diff if the volume array changes.
