### PR TITLE
Volume Access Group improvements

### DIFF
--- a/lib/puppet/type/solidfire_vag.rb
+++ b/lib/puppet/type/solidfire_vag.rb
@@ -26,6 +26,29 @@ Puppet::Type.newtype(:solidfire_vag) do
     def insync?(is)
       is.sort == should.sort
     end
+
+    def change_to_s(currentvalue, newvalue)
+      currentvalue = if currentvalue == :absent || currentvalue.nil?
+                       []
+                     else
+                       currentvalue
+                     end
+      newvalue = if newvalue == :absent
+                   []
+                 else
+                   newvalue
+                 end
+      changes = []
+      removing = currentvalue - newvalue
+      adding = newvalue - currentvalue
+      if removing != []
+        changes << "Removing initiators: #{removing.join(',')}"
+      end
+      if adding != []
+        changes << "Adding initiators: #{adding.join(',')}"
+      end
+      changes.join(' ')
+    end
   end
 
   newproperty(:volumes, :array_matching => :all) do
@@ -33,6 +56,29 @@ Puppet::Type.newtype(:solidfire_vag) do
 
     def insync?(is)
       is.sort == should.sort
+    end
+
+    def change_to_s(currentvalue, newvalue)
+      currentvalue = if currentvalue == :absent || currentvalue.nil?
+                       []
+                     else
+                       currentvalue
+                     end
+      newvalue = if newvalue == :absent
+                   []
+                 else
+                   newvalue
+                 end
+      changes = []
+      removing = currentvalue - newvalue
+      adding = newvalue - currentvalue
+      if removing != []
+        changes << "Removing volumes: #{removing.join(',')}"
+      end
+      if adding != []
+        changes << "Adding volumes: #{adding.join(',')}"
+      end
+      changes.join(' ')
     end
   end
 

--- a/lib/puppet/type/solidfire_vag.rb
+++ b/lib/puppet/type/solidfire_vag.rb
@@ -22,10 +22,18 @@ Puppet::Type.newtype(:solidfire_vag) do
 
   newproperty(:initiators, :array_matching => :all) do
     desc "List of initiators to include in the Volume Access Group"
+
+    def insync?(is)
+      is.sort == should.sort
+    end
   end
 
   newproperty(:volumes, :array_matching => :all) do
     desc "List of Volume Names to include in the Volume Access Group"
+
+    def insync?(is)
+      is.sort == should.sort
+    end
   end
 
   newproperty(:vagid) do


### PR DESCRIPTION
This PR does two things to improve the ability to use volume access groups:

  * Sort the list of VAG initiators and volumes when checking if in sync

    This prevents a permanent diff when the list of either initiators or
volumes is sorted differently from what the API returns
  * Improve readability of changes in VAG initiators and volumes

    Currently the puppet output when initiators or volumes change in a
volume access group is a very hard to read output of an array.  This
changes it to only show what's different, making it much more readable.